### PR TITLE
Improve planner UI and add 4-year plan function

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,30 +1,50 @@
+from __future__ import annotations
+
 from flask import Flask, render_template, request
-import pandas as pd
+
 from recommender import recommend_courses
-from generate_plan import generate_plan
+from generate_plan import generate_4_year_plan
+from utils import load_courses
 
 app = Flask(__name__)
 
-@app.route('/')
+
+@app.route("/")
 def index():
-    df = pd.read_csv('data/towson_courses.csv')
-    courses = df[['course_id', 'course_name']].drop_duplicates().to_dict(orient='records')
-    return render_template('index.html', courses=sorted(courses, key=lambda x: x['course_id']))
+    df = load_courses()
+    courses = (
+        df[["course_id", "course_name"]].drop_duplicates().to_dict(orient="records")
+    )
+    return render_template(
+        "index.html", courses=sorted(courses, key=lambda x: x["course_id"])
+    )
 
-@app.route('/recommend', methods=['POST'])
+
+@app.route("/recommend", methods=["POST"])
 def recommend():
-    track = request.form.get('track')
-    completed_courses = request.form.getlist('completed_courses')
-    recommendations = recommend_courses(track, completed_courses)
-    return render_template('results.html', recommendations=recommendations)
+    track = request.form.get("track")
+    completed_courses = request.form.getlist("completed_courses")
+    recommendations, locked = recommend_courses(track, completed_courses)
+    return render_template(
+        "results.html", recommendations=recommendations, locked=locked
+    )
 
-@app.route('/plan', methods=['POST'])
+
+@app.route("/plan", methods=["POST"])
 def plan():
-    track = request.form.get('track')
-    completed_courses = request.form.getlist('completed_courses')
-    max_credits = request.form.get('max_credits', type=int, default=18)
-    plan, unscheduled = generate_plan(track, completed_courses, max_credits)
-    return render_template('plan.html', plan=plan, unscheduled=unscheduled)
+    track = request.form.get("track")
+    completed_courses = request.form.getlist("completed_courses")
+    max_credits = request.form.get("max_credits", type=int, default=18)
+    plan = generate_4_year_plan(track, completed_courses, max_credits)
 
-if __name__ == '__main__':
+    df = load_courses()
+    total = df["units"].astype(int).sum()
+    completed_df = df[df["course_id"].isin(completed_courses)]
+    completed = completed_df["units"].astype(int).sum()
+    stats = {"completed": int(completed), "total": int(total)}
+
+    return render_template("plan.html", plan=plan, stats=stats)
+
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/generate_plan.py
+++ b/generate_plan.py
@@ -1,13 +1,18 @@
-import pandas as pd
-from typing import List, Tuple, Dict, Set
+from __future__ import annotations
+
+from typing import Dict, List, Set, Tuple
+
 from datetime import datetime
+import pandas as pd
+from utils import load_courses, parse_prereqs
+
 
 def generate_semester_labels() -> List[str]:
-    current_year = datetime.now().year
-    start_season = "Spring" if datetime.now().month <= 6 else "Fall"
-    season = start_season
-    year = current_year
-    labels = []
+    """Create semester labels starting with the upcoming fall term."""
+    now = datetime.now()
+    year = now.year if now.month < 6 else now.year + 1
+    season = "Fall"
+    labels: List[str] = []
     for _ in range(8):
         labels.append(f"{season} {year}")
         if season == "Fall":
@@ -16,6 +21,7 @@ def generate_semester_labels() -> List[str]:
         else:
             season = "Fall"
     return labels
+
 
 SEMESTER_LABELS = generate_semester_labels()
 
@@ -26,91 +32,57 @@ INTERCHANGEABLE_SETS: List[Set[str]] = [
     {"CIS212", "COSC236"},
 ]
 
-PREREQ_MAP: Dict[str, List[str]] = {
-    "COSC236": ["COSC175"],
-    "COSC237": ["COSC236"],
-    "CIS239": ["CIS211"],
-    "CIS350": [],
-    "CIS377": [],
-    "CIS379": ["COSC237"],
-    "CIS435": [],
-    "CIS458": ["CIS239"],
-    "CIS479": ["CIS379"],
-    "CIS475": ["CIS479", "CIS458"],
-    "ENGL317": ["ENGL102"],
-    "COSC418": ["ENGL102"],
-    "CIS328": ["CIS211"],
-    "CIS334": ["CIS379"],
-    "CIS428": ["CIS328", "CIS334"],
-    "CIS468": ["MATH231", "CIS334"],
-    "ITEC336": [],
-    "COSC336": ["COSC237"],
-    "CIS265": [],
-    "CIS397": ["CIS334"],
-    "CIS426": ["CIS328"],
-    "CIS436": ["CIS379"],
-    "ITEC427": ["ITEC231"],
-    "COSC412": ["COSC336"],
-    "COSC436": ["COSC336"],
-    "COSC484": ["COSC336"],
-    "CIS212": [],
-    "CIS425": ["CIS379", "MATH231"],
-    "CIS440": ["CIS379"],
-    "CIS495": [],
-    "ITEC345": ["COSC236", "MATH263"],
-    "ITEC423": ["ITEC231"],
-    "ART102": [],
-    "ART103": [],
-    "ART217": ["ART103"],
-    "ART322": ["ART217"],
-    "ACCT201": [],
-    "ECON201": [],
-    "ECON203": [],
-    "ECON205": ["ECON201"],
-    "LEGL225": [],
-    "MKTG341": ["ECON201"],
-    "MNGT361": ["ECON201"],
-    "FIN331": ["ACCT201", "ECON205"],
-    "ACCT202": ["ACCT201"],
-    "ACCT301": ["ACCT202"],
-    "ACCT341": ["ACCT202"],
-    "EBTM419": ["EBTM365"],
-    "EBTM454": ["EBTM365"],
-    "HCMN305": ["HLTH207"],
-    "MNGT395": ["MNGT361"],
-    "ITEC433": [],
-}
 
-def generate_plan(track: str, completed_courses: List[str], max_credits: int = 18) -> Tuple[List[Dict], List[Dict]]:
-    df = pd.read_csv('data/towson_courses.csv')
-    df = df[(df['track'] == 'All') | (df['track'] == track)].copy()
+def generate_4_year_plan(
+    student_track: str, completed_courses: List[str], max_units: int
+) -> List[Dict]:
+    """Return an eight-semester plan for the given track."""
+
+    plan, _ = generate_plan(student_track, completed_courses, max_units)
+
+    while len(plan) < 8:
+        plan.append(
+            {"semester": SEMESTER_LABELS[len(plan)], "courses": [], "credits": 0}
+        )
+
+    return plan
+
+
+def generate_plan(
+    track: str, completed_courses: List[str], max_credits: int = 18
+) -> Tuple[List[Dict], List[Dict]]:
+    df = load_courses()
+    df = df[(df["track"] == "All") | (df["track"] == track)].copy()
 
     done_set: Set[str] = set(completed_courses)
     for course_set in INTERCHANGEABLE_SETS:
         if done_set.intersection(course_set):
             done_set.update(course_set)
 
-    df = df[~df['course_id'].isin(done_set)].copy()
+    df = df[~df["course_id"].isin(done_set)].copy()
+
+    catalog_ids: Set[str] = set(df["course_id"].tolist())
 
     def met_prereqs(course_id: str) -> bool:
-        prereqs = PREREQ_MAP.get(course_id, [])
-        return all(pr in done_set for pr in prereqs)
+        row = df[df["course_id"] == course_id].iloc[0]
+        prereqs = parse_prereqs(row.get("prerequisites", ""))
+        return all(pr in done_set or pr not in catalog_ids for pr in prereqs)
 
     def label(row: pd.Series) -> str:
-        if row['core_required'] == 'yes' and row['track'] == 'All':
-            return 'Core'
-        if row['core_required'] == 'yes' and row['track'] == track:
-            return 'Track Core'
-        if row['elective'] == 'yes' and row['track'] == track:
-            return 'Track Elective'
-        if row['elective'] == 'yes':
-            return 'Elective'
-        return 'Other'
+        if row["core_required"] == "yes" and row["track"] == "All":
+            return "Core"
+        if row["core_required"] == "yes" and row["track"] == track:
+            return "Track Core"
+        if row["elective"] == "yes" and row["track"] == track:
+            return "Track Elective"
+        if row["elective"] == "yes":
+            return "Elective"
+        return "Other"
 
-    df['category'] = df.apply(label, axis=1)
-    df['priority'] = df['category'].map({
-        'Core': 0, 'Track Core': 1, 'Track Elective': 2, 'Elective': 3, 'Other': 4
-    })
+    df["category"] = df.apply(label, axis=1)
+    df["priority"] = df["category"].map(
+        {"Core": 0, "Track Core": 1, "Track Elective": 2, "Elective": 3, "Other": 4}
+    )
 
     plan = []
     remaining = df.copy()
@@ -120,32 +92,37 @@ def generate_plan(track: str, completed_courses: List[str], max_credits: int = 1
         credits = 0
 
         while credits < max_credits:
-            available = remaining[remaining['course_id'].apply(met_prereqs)]
+            if remaining.empty:
+                break
+            available = remaining[remaining["course_id"].apply(met_prereqs)]
             if available.empty:
                 break
 
-            available = available.sort_values(by=['priority', 'course_id'])
+            available = available.sort_values(by=["priority", "course_id"])
             placed = False
 
             for idx, row in available.iterrows():
-                units = int(row['units'])
+                units = int(row["units"])
                 if credits + units > max_credits:
                     continue
 
-                sem_courses.append({
-                    'course_id': row['course_id'],
-                    'course_name': row['course_name'],
-                    'units': units,
-                    'category': row['category']
-                })
+                sem_courses.append(
+                    {
+                        "course_id": row["course_id"],
+                        "course_name": row["course_name"],
+                        "units": units,
+                        "category": row["category"],
+                        "prerequisites": parse_prereqs(row.get("prerequisites", "")),
+                    }
+                )
                 credits += units
-                course_id = row['course_id']
+                course_id = row["course_id"]
                 done_set.add(course_id)
 
                 for cset in INTERCHANGEABLE_SETS:
                     if course_id in cset:
                         done_set.update(cset)
-                        remaining = remaining[~remaining['course_id'].isin(cset)]
+                        remaining = remaining[~remaining["course_id"].isin(cset)]
                         break
                 else:
                     remaining = remaining.drop(idx)
@@ -157,28 +134,43 @@ def generate_plan(track: str, completed_courses: List[str], max_credits: int = 1
                 break
 
             if credits >= 15:
-                more = remaining[remaining['course_id'].apply(met_prereqs)]
-                fits = any(credits + int(u) <= max_credits for u in more['units'].astype(int).tolist())
+                if remaining.empty:
+                    break
+                more = remaining[remaining["course_id"].apply(met_prereqs)]
+                fits = any(
+                    credits + int(u) <= max_credits
+                    for u in more["units"].astype(int).tolist()
+                )
                 if not fits:
                     break
 
         if sem_courses:
             label = SEMESTER_LABELS[sem]
-            plan.append({'semester': label, 'courses': sem_courses, 'credits': credits})
+            plan.append({"semester": label, "courses": sem_courses, "credits": credits})
         if remaining.empty:
             break
 
-    unscheduled = remaining[['course_id', 'course_name', 'category']].to_dict('records')
+    remaining = remaining.copy()
+    remaining["prerequisites"] = remaining["prerequisites"].apply(parse_prereqs)
+    unscheduled = remaining[
+        ["course_id", "course_name", "category", "prerequisites"]
+    ].to_dict("records")
     return plan, unscheduled
 
+
 if __name__ == "__main__":
-    import argparse, json
+    import argparse
+    import json
 
     parser = argparse.ArgumentParser(description="Generate 4-year plan")
     parser.add_argument("--track", required=True, help="Selected track")
-    parser.add_argument("--completed", nargs="*", default=[], help="Completed course IDs")
-    parser.add_argument("--max-credits", type=int, default=18, help="Maximum credits per semester")
+    parser.add_argument(
+        "--completed", nargs="*", default=[], help="Completed course IDs"
+    )
+    parser.add_argument(
+        "--max-credits", type=int, default=18, help="Maximum credits per semester"
+    )
     args = parser.parse_args()
 
-    plan, unscheduled = generate_plan(args.track, args.completed, args.max_credits)
-    print(json.dumps({"plan": plan, "unscheduled": unscheduled}, indent=2))
+    plan = generate_4_year_plan(args.track, args.completed, args.max_credits)
+    print(json.dumps({"plan": plan}, indent=2))

--- a/recommender.py
+++ b/recommender.py
@@ -1,36 +1,52 @@
+from __future__ import annotations
+
 import pandas as pd
 
-def recommend_courses(track, completed_courses):
-    df = pd.read_csv('data/towson_courses.csv')
+from utils import load_courses, parse_prereqs
+
+
+def recommend_courses(track: str, completed_courses: list[str]):
+    """Return recommended and locked courses for the given track."""
+    df = load_courses()
 
     # Convert completed list for quick lookup
     completed_set = set(completed_courses)
 
     # Filter out already completed courses
-    df = df[~df['course_id'].isin(completed_set)]
+    df = df[~df["course_id"].isin(completed_set)]
 
-    # Filter out courses whose prerequisites are NOT met
-    def has_met_prereqs(prereq_str):
-        if pd.isna(prereq_str) or prereq_str.strip() == "":
-            return True
-        prereqs = [pr.strip() for pr in prereq_str.split(',')]
-        return all(pr in completed_set for pr in prereqs)
+    locked: list[dict] = []
+    available_rows = []
 
-    df = df[df['prerequisites'].apply(has_met_prereqs)]
+    for _, row in df.iterrows():
+        prereqs = parse_prereqs(row["prerequisites"])
+        unmet = [p for p in prereqs if p not in completed_set]
+        if unmet:
+            locked.append({"course_id": row["course_id"], "missing": unmet})
+        else:
+            available_rows.append(row)
+
+    if available_rows:
+        df = pd.DataFrame(available_rows)
+    else:
+        df = pd.DataFrame(columns=df.columns)
 
     # Score each course based on relevance
     def score_course(row):
         score = 0
-        if row['core_required'] == 'yes':
+        if row["core_required"] == "yes":
             score += 3
-        if row['track'] == track:
+        if row["track"] == track:
             score += 2
-        if row['elective'] == 'yes':
+        if row["elective"] == "yes":
             score += 1
         return score
 
-    df['score'] = df.apply(score_course, axis=1)
+    df["score"] = df.apply(score_course, axis=1)
 
     # Return top recommendations (sorted by score then course ID)
-    recommendations = df.sort_values(by=['score', 'course_id'], ascending=[False, True])
-    return recommendations[['course_id', 'course_name', 'score']].to_dict(orient='records')
+    recommendations = df.sort_values(by=["score", "course_id"], ascending=[False, True])
+    recs = recommendations[["course_id", "course_name", "score"]].to_dict(
+        orient="records"
+    )
+    return recs, locked

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,47 @@
+body {
+    background: linear-gradient(45deg, #fdfbfb, #ebedee);
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: #333;
+}
+
+h1, h2, h3, h4 {
+    font-weight: 600;
+}
+
+.btn-primary {
+    background-color: #e1306c;
+    border-color: #e1306c;
+}
+
+.btn-primary:hover {
+    background-color: #d62463;
+    border-color: #d62463;
+}
+
+.btn-secondary {
+    background-color: #262626;
+    border-color: #262626;
+}
+
+.btn-secondary:hover {
+    background-color: #000;
+    border-color: #000;
+}
+
+.table-striped>tbody>tr:nth-of-type(odd) {
+    --bs-table-accent-bg: rgba(0,0,0,0.03);
+}
+
+.list-group-item {
+    border: none;
+    border-bottom: 1px solid #eee;
+}
+
+.course-tag {
+    font-size: 0.75rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background-color: #fafafa;
+    border: 1px solid #e0e0e0;
+    margin-left: 8px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Towson IS PathFinder</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="bg-light">
 <main class="container py-4">
     <h1 id="pageTitle" class="mb-4">Towson IS PathFinder</h1>
-    <form method="POST" action="/plan" aria-labelledby="pageTitle">
+    <form method="POST" action="/plan" aria-labelledby="pageTitle" class="vstack gap-4">
         <div class="mb-3">
             <label for="track" class="form-label">Select your track</label>
             <select id="track" name="track" class="form-select" required>
@@ -41,7 +42,10 @@
             </div>
         </fieldset>
 
-        <button type="submit" class="btn btn-primary">Generate Plan</button>
+        <div class="d-flex gap-2">
+            <button type="submit" formaction="/recommend" class="btn btn-secondary">Get Recommendations</button>
+            <button type="submit" class="btn btn-primary">Generate Plan</button>
+        </div>
     </form>
 </main>
 </body>

--- a/templates/plan.html
+++ b/templates/plan.html
@@ -5,52 +5,38 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>4-Year Plan</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="bg-light">
 <main class="container py-4">
     <h1 class="mb-4">Generated 4-Year Plan</h1>
-
-    <div class="accordion mb-4" id="planAccordion">
-        {% for sem in plan %}
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading{{ loop.index }}">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ loop.index }}" aria-expanded="false" aria-controls="collapse{{ loop.index }}">
-                    {{ sem.semester }} ({{ sem.credits }} credits)
-                </button>
-            </h2>
-            <div id="collapse{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#planAccordion">
-                <div class="accordion-body p-0">
-                    <ul class="list-group list-group-flush">
-                        {% for c in sem.courses %}
-                        <li class="list-group-item d-flex justify-content-between align-items-center">
-                            <span>
-                                <strong>{{ c.course_id }}</strong> - {{ c.course_name }}
-                                <span class="badge bg-info text-dark ms-2">{{ c.category }}</span>
-                            </span>
-                            <span class="badge bg-secondary">{{ c.units }} cr</span>
-                        </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
-        {% endfor %}
-    </div>
-
-    {% if unscheduled %}
-    <h2 class="h5 mt-5">Unscheduled Courses</h2>
-    <ul class="list-group">
-        {% for c in unscheduled %}
-        <li class="list-group-item">
-            <strong>{{ c.course_id }}</strong> - {{ c.course_name }} ({{ c.category }})
-        </li>
-        {% endfor %}
-    </ul>
-    {% endif %}
-
+    <p class="mb-3">Credits Completed: {{ stats.completed }} / {{ stats.total }}</p>
+    {% set year_names = ['Freshman', 'Sophomore', 'Junior', 'Senior'] %}
+    {% for sem in plan %}
+        {% if loop.index0 % 2 == 0 %}
+            <h2 class="mt-4">{{ year_names[loop.index0 // 2] }} Year</h2>
+        {% endif %}
+        <h4>{{ sem.semester }}</h4>
+        <table class="table table-striped table-sm mb-3">
+            <thead>
+                <tr><th>Course</th><th>Units</th></tr>
+            </thead>
+            <tbody>
+            {% for c in sem.courses %}
+                <tr>
+                    <td>{{ c.course_id }} - {{ c.course_name }}</td>
+                    <td>{{ c.units }}</td>
+                </tr>
+            {% endfor %}
+            <tr class="table-secondary">
+                <th>Total Units</th>
+                <th>{{ sem.credits }}</th>
+            </tr>
+            </tbody>
+        </table>
+    {% endfor %}
     <a href="/" class="btn btn-secondary mt-4">Back</a>
 </main>
-
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,42 +1,43 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Recommended Courses</title>
-    <style>
-        body { font-family: Arial, sans-serif; padding: 2rem; background: #f9f9f9; }
-        h1 { color: #333; }
-        .course-box {
-            padding: 10px;
-            margin-bottom: 10px;
-            background: white;
-            border-left: 4px solid #4caf50;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-        }
-        .back-btn {
-            margin-top: 20px;
-            display: inline-block;
-            padding: 10px 20px;
-            background: #4caf50;
-            color: white;
-            text-decoration: none;
-            border-radius: 4px;
-        }
-    </style>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-    <h1>Recommended Courses</h1>
+    <main class="container py-4">
+    <h1 class="mb-4">Recommended Courses</h1>
 
     {% if recommendations %}
+        <div class="list-group mb-4">
         {% for course in recommendations %}
-            <div class="course-box">
-                <strong>{{ course.course_id }}</strong> - {{ course.course_name }}<br>
-                <small>Relevance Score: {{ course.score }}</small>
+            <div class="list-group-item d-flex justify-content-between align-items-start">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">{{ course.course_id }} - {{ course.course_name }}</div>
+                    <small class="text-muted">Score: {{ course.score }}</small>
+                </div>
             </div>
         {% endfor %}
+        </div>
     {% else %}
         <p>No recommendations available based on your completed courses.</p>
     {% endif %}
 
-    <a class="back-btn" href="/">Back to Form</a>
+    {% if locked %}
+    <h2 class="h5 mt-4">Locked Courses</h2>
+    <ul class="list-group">
+        {% for l in locked %}
+        <li class="list-group-item">
+            {{ l.course_id }} - requires {{ l.missing | join(', ') }}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    <a class="btn btn-secondary mt-4" href="/">Back</a>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import re
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def load_courses() -> pd.DataFrame:
+    """Load course catalog from CSV."""
+    df = pd.read_csv("data/towson_courses.csv")
+    return df
+
+
+def parse_prereqs(prereq_str: str) -> list[str]:
+    """Return list of prerequisite course IDs."""
+    if pd.isna(prereq_str) or prereq_str == "":
+        return []
+    parts = re.split(r"[;,]", prereq_str)
+    return [p.strip() for p in parts if p.strip()]


### PR DESCRIPTION
## Summary
- create `generate_4_year_plan` for fixed 8-semester output
- use the new function in the Flask app
- simplify plan template with catalog-style tables
- add high-end styling and dynamic semester labels
- ensure prerequisite handling doesn't break when catalog is empty

## Testing
- `black app.py recommender.py generate_plan.py utils.py --check`
- `ruff check app.py recommender.py generate_plan.py utils.py`
- `python3 -m py_compile app.py generate_plan.py recommender.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_687d3fc462ac833398b4e7ee87e434ee